### PR TITLE
Fix grammar in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ To install the app, we have to do the following:
    ```bash
    ollama pull MODEL_NAME
    ```
-   Replace MODEL_NAME with your desired model name. List of all the models is available at this [link](https://ollama.com/download).
+   Replace MODEL_NAME with your desired model name. List of all the models are available at this [link](https://ollama.com/download).
 
 7. Open the source directory, where the source code exists. Then, keep the documents that you want to analyze in the DATA_DOCUMENTS folder.
 


### PR DESCRIPTION
## Summary
- fix grammatical error in model installation section of the readme

## Testing
- `pylint $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68639dfec1e4832a90f01a65b8d0d3ef