### PR TITLE
Fix CHUNK_SIZE parsing in ingest script

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -32,7 +32,7 @@ import sys
 
 # EMBEDDING_MODEL_NAME = sys.argv[1]  # Retrieve the passed value
 EMBEDDING_MODEL_NAME = sys.argv[1] if len(sys.argv) > 1 else None
-CHUNK_SIZE = int(sys.argv[2]) if len(sys.argv) > 1 else None
+CHUNK_SIZE = int(sys.argv[2]) if len(sys.argv) > 2 else None
 
 print(f"Received value: {EMBEDDING_MODEL_NAME}")
 print(f"CHUNK_SIZE: {CHUNK_SIZE}")


### PR DESCRIPTION
## Summary
- ensure `ingest.py` reads `CHUNK_SIZE` only when the value is provided

## Testing
- `python3 -m py_compile ingest.py`


------
https://chatgpt.com/codex/tasks/task_e_68639f0c2db4832a9544a60bc9b1021e